### PR TITLE
Bumped up versions for main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ ENV POETRY_HOME=/usr/local
 # Ref: https://deb.nodesource.com/setup_14.x
 # Ref: https://yarnpkg.com/en/docs/install
 RUN \
-  echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_16.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   apt-get update && \
   apt-get install -yqq nodejs yarn && \
   pip install -U pip && pip install pipenv && \
-  npm i -g npm@^6 && \
+  npm i -g npm@^8 && \
   curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Bumped up 
- nodejs 14.x -> 16.x (Current LTS version)
- npm  6.x -> 8.x 