### PR TITLE
build: Update poetry installation method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN \
   apt-get install -yqq nodejs yarn && \
   pip install -U pip && pip install pipenv && \
   npm i -g npm@^8 && \
-  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - && \
+  curl -sSL https://install.python-poetry.org | python - && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The installation method in the current Dockerfile is considered "deprecated" as of v1.2.0, see the disclaimer on their website: https://python-poetry.org/docs/#installation