### PR TITLE
💥 Roll node to v20 + use default npm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ LABEL org.opencontainers.image.authors="Nikolai R Kristiansen <nikolaik@gmail.co
 RUN groupadd --gid 1000 pn && useradd --uid 1000 --gid pn --shell /bin/bash --create-home pn
 ENV POETRY_HOME=/usr/local
 # Install node prereqs, nodejs and yarn
-# Ref: https://deb.nodesource.com/setup_18.x
+# Ref: https://deb.nodesource.com/setup_20.x
 # Ref: https://yarnpkg.com/en/docs/install
 RUN \
-  echo "deb https://deb.nodesource.com/node_18.x bullseye main" > /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_20.x bullseye main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
@@ -15,6 +15,5 @@ RUN \
   apt-get upgrade -yqq && \
   apt-get install -yqq nodejs yarn && \
   pip install -U pip && pip install pipenv && \
-  npm i -g npm@^8 && \
   curl -sSL https://install.python-poetry.org | python - && \
   rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Last updated by bot: 2023-05-05
 
 The `latest` tag is currently:
 
-- Node: 18.x
-- npm: 8.x
+- Node: 20.x
+- npm: 9.x
 - yarn: stable
 - Python: latest
 - pip: latest

--- a/build_versions/dockerfiles.py
+++ b/build_versions/dockerfiles.py
@@ -25,10 +25,7 @@ def _render_template(template_name, **context):
 def render_dockerfile(version, node_gpg_keys):
     distro = "debian" if version["distro"] != "alpine" else version["distro"]
 
-    node_major_version = 15
     context = {
-        # NPM: Hold back on v8 for nodejs<15
-        "npm_version": "6" if int(version["nodejs"]) < node_major_version else "8",
         "now": datetime.utcnow().isoformat()[:-7],
         "node_gpg_keys": node_gpg_keys,
         **version,

--- a/templates/alpine.Dockerfile
+++ b/templates/alpine.Dockerfile
@@ -27,7 +27,6 @@ MAINTAINER Nikolai R Kristiansen <nikolaik@gmail.com>
 RUN addgroup -g 1000 pn && adduser -u 1000 -G pn -s /bin/sh -D pn
 RUN apk add libstdc++
 COPY --from=builder /node-v{{ nodejs_canonical }}-linux-x64-musl /usr/local
-RUN npm i -g npm@^{{ npm_version }} yarn
 RUN pip install -U pip && pip install pipenv
 
 # Poetry

--- a/templates/debian.Dockerfile
+++ b/templates/debian.Dockerfile
@@ -19,6 +19,5 @@ RUN \
   apt-get install -yqq nodejs=$(apt-cache show nodejs|grep Version|grep nodesource|cut -c 10-) yarn && \
   apt-mark hold nodejs && \
   pip install -U pip && pip install pipenv && \
-  npm i -g npm@^{{ npm_version }} && \
   wget -qO- https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This stops overriding the npm version in images and instead using the
default version. This was previously done with older nodes that bundled too
old npm versions.

Also rolls node version in latest tag to v20
