### PR TITLE
Update README.md (updated latest node version to 22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Last updated by bot: 2024-04-25
 
 The `latest` tag is currently:
 
-- Node.js: 20.x
+- Node.js: 22.x
 - npm: 9.x
 - yarn: stable
 - Python: latest


### PR DESCRIPTION
Node.js 22 is now available!
The latest tag is pointing to the node v 22.x now

https://nodejs.org/en/blog/announcements/v22-release-announce