### PR TITLE
🐛 Authenticate to Docker Hub in release job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,6 +130,9 @@ jobs:
           else
               echo "Nothing changed, nothing to archive."
           fi
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PUBLIC_TOKEN: ${{ secrets.DOCKERHUB_PUBLIC_TOKEN }}
 
   test:
     uses: ./.github/workflows/tests.yaml


### PR DESCRIPTION
This uses a public package scoped token for the tag lookups

Fixes https://github.com/nikolaik/docker-python-nodejs/actions/runs/33371244305/job/99446113804